### PR TITLE
Fix responsiveness issue with buttons in hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,18 @@
   }
 }
 
+@media screen and (max-width: 600px) {
+
+  .buttons {
+    flex-wrap: wrap;
+  }
+
+  .button {
+    flex: 1;
+  }
+
+}
+
 
     .card {
       background-color: #fff;


### PR DESCRIPTION
The four buttons inside the `hero-section` were not being shown properly on small screens. Added a media query for smaller screens that simply allows the buttons to wrap.