### PR TITLE
Fix touchstart event go beyond the z-indexed elements and causing other elements to respond

### DIFF
--- a/script.js
+++ b/script.js
@@ -2780,7 +2780,7 @@
         }
       }
     }
-
+    
     function showModal(term) {
       const modal = document.getElementById('modal');
       const modalBody = document.getElementById('modal-body');
@@ -2812,14 +2812,17 @@
       modal.style.display = 'block';
     }
 
-   // Function to close the modal
+// Function to close the modal
+const modal = document.getElementById('modal');
 function closeModal(event) {
-  const modal = document.getElementById('modal');
-  if (event.target == modal) {
+  event.preventDefault();
+  const learnMoreLink = event.target.getAttribute('href') ?? undefined;
+  if(event.target === modal)
     modal.style.display = 'none';
-  }
+  else if(learnMoreLink) 
+    window.open(learnMoreLink, '_blank').focus();
 }
 
 // Add event listeners for both click and touchstart
-window.addEventListener('click', closeModal);
-window.addEventListener('touchstart', closeModal);
+modal.addEventListener('touchstart', closeModal)
+modal.addEventListener('click', closeModal)

--- a/script.js
+++ b/script.js
@@ -2795,7 +2795,7 @@ const descriptions = {  codeSmell: `
         }
       }
     }
-    
+
     function showModal(term) {
       const modal = document.getElementById('modal');
       const modalBody = document.getElementById('modal-body');
@@ -2839,5 +2839,5 @@ function closeModal(event) {
 }
 
 // Add event listeners for both click and touchstart
-modal.addEventListener('touchstart', closeModal)
-modal.addEventListener('click', closeModal)
+modal.addEventListener('touchstart', closeModal);
+modal.addEventListener('click', closeModal);


### PR DESCRIPTION
**Issue:** The "touchstart" event handler closes the modal and the event still propagates to the other elements in the DOM. 
**Fix:**  The event "touchstart" event listener is added only to the modal and the default behavior of the event has been stopped. If the user clicks the anchor tag, the user will be redirected to the new tab. In other cases the modal will be closed if the user touches the modal in any touch devices.