### PR TITLE
aligning all buttons in same line

### DIFF
--- a/style.css
+++ b/style.css
@@ -118,6 +118,10 @@ body {
     border-radius: 10px;
     padding: 20px;
     text-align: center;
+    display:flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .card-title {


### PR DESCRIPTION
When two or more modals were side-by-side , The "Explain" buttons were unaligned. This happened when viewed from tablet or desktop devices. 

Only CSS have been changed.

