### PR TITLE
Fix touchstart event interfere with other elements after closing the modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -2808,12 +2808,13 @@ const descriptions = {  codeSmell: `
         }
       }
     }
-
+    const cardContainer = document.getElementById('cardContainer');
     function showModal(term) {
       const modal = document.getElementById('modal');
       const modalBody = document.getElementById('modal-body');
       modalBody.innerHTML = descriptions[term];
       modal.style.display = 'block';
+      cardContainer.style.pointerEvents = 'none';
     }
 
     function readMore() {
@@ -2845,6 +2846,9 @@ function closeModal(event) {
   const modal = document.getElementById('modal');
   if (event.target == modal) {
     modal.style.display = 'none';
+    setTimeout(() => {
+      cardContainer.style.pointerEvents = 'all';
+    },500)
   }
 }
 


### PR DESCRIPTION
**Issue:** The button behind the modal is getting clicked once the modal is closed.
**Fix:** Remove the all the pointer events from the card container when the modal is shown. And add all the pointer events to the cardContainer once the modal is closed after certain delay (ex: 500 ms) so that the "touchstart" event doesn't click the buttons behind.