### PR TITLE
correctly link cSharp card to cSharp modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,7 +543,7 @@
   <div class="card">
     <div class="card-title">C#</div>
     <div class="card-subtext">A modern, OOP language from Microsoft</div>
-    <button class="explain-button" onclick="showModal('C#')">Explain</button>
+    <button class="explain-button" onclick="showModal('cSharp')">Explain</button>
   </div>
   <div class="card">
     <div class="card-title">Ruby</div>


### PR DESCRIPTION
the C# 'explain' button does not open.

I believe this is due to the mismatched names between index and script