### PR TITLE
Turned browser's default auto-complete off.

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,7 +2,7 @@
   
   <div class="search-bar position-relative" style="padding-bottom: 30px;">
     <i class="fas fa-search"></i>
-    <input type="text" id="searchInput" class="form-control" placeholder="Search for keywords..." />
+    <input  autocomplete="off" type="text" id="searchInput" class="form-control" placeholder="Search for keywords..." />
     <div id="autocomplete-list"></div> 
   </div>
 


### PR DESCRIPTION
There was an issue regarding the browser's default autocomplete showing up, whenever searching a topic, which was causing the custom autocomplete menu to be hidden behind it.

![Screenshot 2024-08-20 223447](https://github.com/user-attachments/assets/cf712cd0-c63c-4fad-b220-b1f74179a5ff)


Fixed it by adding setting "autocomplete" attribute to be "off"