### PR TITLE
Feature: close modal on escape key press, Fix scroll behavior #110

### DIFF
--- a/public/card-actions.js
+++ b/public/card-actions.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const buttons = document.querySelectorAll('.explain-button');
-
+  const modal = document.getElementById("modal");
+  const body = document.body;
+  
   buttons.forEach((button) => {
     button.addEventListener('click', (event) => {
       const card = event.target.closest('.card');
@@ -17,9 +19,15 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Close the modal when clicking outside of it
-  const modal = document.getElementById('modal');
   modal.addEventListener('click', (event) => {
     if (event.target === modal) {
+      closeModal();
+    }
+  });
+
+  // Close the modal when pressing the Escape key
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && modal.style.display === 'block') {
       closeModal();
     }
   });
@@ -40,12 +48,13 @@ document.addEventListener('DOMContentLoaded', () => {
       ${imageElement} <!-- Only include the image if imageUrl is not empty -->
       <a href="${resourceUrl}" id="modal-link" target="_blank">⌁—— Learn more about ${title} ——⌁</a>
     `;
-    document.getElementById('modal').style.display = 'block';
+    modal.style.display = 'block';
+    body.classList.add("modal-open");
   }
 
   // Function to close the modal
   function closeModal() {
-    const modal = document.getElementById('modal');
     modal.style.display = 'none';
+    body.classList.remove("modal-open");
   }
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -358,7 +358,7 @@ body.dark-mode input[type="text"]::placeholder {
   top: 0;
   width: 100%;
   height: 100%;
-  overflow: auto;
+  overflow-y: hidden;
   background-color: rgba(0, 0, 0, 0.5);
 }
 
@@ -374,6 +374,10 @@ body.dark-mode input[type="text"]::placeholder {
   font-family: 'JetBrains Mono', monospace;
   overflow-y: auto;
   max-height: 70vh;
+}
+
+body.modal-open {
+  overflow: hidden;
 }
 
 #modal-body {


### PR DESCRIPTION
### Here's a description of the changes #110 

1. Close modal on Escape key press: Added an event listener for the 'keydown' event on the document.
2. Fix scroll behavior: This will prevent the main page from scrolling when the modal opens.

**These changes improve the user experience by allowing users to close the modal using the Escape key and preventing unwanted scrolling behavior when the modal is open.**
