### PR TITLE
Set the theme from LocalStorage on DOMContentLoaded event

### DIFF
--- a/public/hero-action.js
+++ b/public/hero-action.js
@@ -3,6 +3,10 @@ document.addEventListener('DOMContentLoaded', async function() {
     document.getElementById('builderButton').addEventListener('click', showBuilders);
     document.getElementById('sponsorButton').addEventListener('click', showSponsors);
     document.getElementById('darkModeToggle').addEventListener('click', toggleDarkMode);
+    const darkModeHTML = `<i class="fas fa-moon" style="padding-right: 10px;"></i><span id="darkModeText"> Dark Mode;</span>`;
+    const lightModeHTML = `<i class="fas fa-sun" style="padding-right: 10px;"></i><span id="darkModeText"> Light Mode;</span>`;
+
+    setTheme();
 
     const searchInput = document.getElementById('searchInput');
 
@@ -206,22 +210,22 @@ document.addEventListener('DOMContentLoaded', async function() {
       
       if (body.classList.contains('dark-mode')) {
           localStorage.setItem('darkMode', 'enabled');
-          toggleButton.innerHTML = '<i class="fas fa-sun" style="padding-right: 10px;"></i><span id="darkModeText"> Light Mode;</span>';
+          toggleButton.innerHTML = lightModeHTML;
       } else {
           localStorage.setItem('darkMode', 'disabled');
-          toggleButton.innerHTML = '<i class="fas fa-moon" style="padding-right: 10px;"></i><span id="darkModeText"> Dark Mode;</span>';
+          toggleButton.innerHTML = darkModeHTML;
       }
     }
     
-    window.onload = function() {
+    function setTheme() {
       const darkMode = localStorage.getItem('darkMode');
       const toggleButton = document.getElementById('darkModeToggle');
       
       if (darkMode === 'enabled') {
           document.body.classList.add('dark-mode');
-          toggleButton.innerHTML = '<i class="fas fa-sun" style="padding-right: 10px;"></i><span id="darkModeText"> Light Mode;</span>';
+          toggleButton.innerHTML = lightModeHTML;
       } else {
-          toggleButton.innerHTML = '<i class="fas fa-moon" style="padding-right: 10px;"></i><span id="darkModeText"> Dark Mode;</span>';
+          toggleButton.innerHTML = darkModeHTML;
       }
-    };
+    }
 });

--- a/public/hero-action.js
+++ b/public/hero-action.js
@@ -204,28 +204,36 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     function toggleDarkMode() {
       const body = document.body;
-      const toggleButton = document.getElementById('darkModeToggle');
-      
-      body.classList.toggle('dark-mode');
       
       if (body.classList.contains('dark-mode')) {
-          localStorage.setItem('darkMode', 'enabled');
-          toggleButton.innerHTML = lightModeHTML;
+        handleSetTheme('light');
       } else {
-          localStorage.setItem('darkMode', 'disabled');
-          toggleButton.innerHTML = darkModeHTML;
+        handleSetTheme('dark');
       }
     }
+
+    function handleSetTheme(theme) {
+        const body = document.body;
+        const toggleButton = document.getElementById('darkModeToggle');
+
+        if (theme === 'dark') {
+          localStorage.setItem('theme', 'dark');
+          body.classList.add('dark-mode');
+          toggleButton.innerHTML = darkModeHTML;
+        } else {
+          localStorage.setItem('theme', 'light');
+          body.classList.remove('dark-mode');
+          toggleButton.innerHTML = lightModeHTML;
+        }
+      }
     
     function setTheme() {
-      const darkMode = localStorage.getItem('darkMode');
-      const toggleButton = document.getElementById('darkModeToggle');
+      const theme = localStorage.getItem('theme');
       
-      if (darkMode === 'enabled') {
-          document.body.classList.add('dark-mode');
-          toggleButton.innerHTML = lightModeHTML;
+      if (theme === 'dark') {
+        handleSetTheme('dark')
       } else {
-          toggleButton.innerHTML = darkModeHTML;
+        handleSetTheme('light');
       }
     }
 });


### PR DESCRIPTION
## Issue:
When the page is reloaded or loaded for the first time, even if we have enabled dark mode in the past, the page still loads into Light mode.
[darkmode_pageload_issue.webm](https://github.com/user-attachments/assets/0e94415c-ac72-4d53-82ff-e2aea85a247e)

## RCA:
The darkMode property is set in localStorage and read from localStorage on `window.onload` event which gets triggered after the resources are downloaded and loaded into storage system. Rather than using `window.onload`, adding the functionality in `DOMContentLoaded` event should solve the problem.

## Is it tested:
Yes
[darkmode_issue_fix.webm](https://github.com/user-attachments/assets/240f88d2-5399-45a6-b8db-f89ac154bee2)

## What is the change:
Extracted the window.load callback into a function and called from `DOMContentLoaded` event so that when DOM elements are loaded, the choosen theme is set.

See issue: #115 