### PR TITLE
fix: Navbar bug 

### DIFF
--- a/src/scripts/hero-action.ts
+++ b/src/scripts/hero-action.ts
@@ -187,8 +187,8 @@ document
 document
   .getElementById("darkModeToggle")!
   .addEventListener("click", toggleDarkMode)
-const darkModeHTML = `<i class="fas fa-moon" style="padding-right: 10px;"></i><span id="darkModeText"> Dark Mode</span>`
-const lightModeHTML = `<i class="fas fa-sun" style="padding-right: 10px;"></i><span id="darkModeText"> Light Mode</span>`
+const darkModeHTML = `<i class="fas fa-moon" style="padding-right: 10px;"></i><span id="darkModeText"> Light Mode</span>`
+const lightModeHTML = `<i class="fas fa-sun" style="padding-right: 10px;"></i><span id="darkModeText"> Dark Mode</span>`
 
 setTheme()
 


### PR DESCRIPTION
## What does this PR do?

It fixes a bug in the navbar of the home page. When the theme is dark , then there is a light mode option and when the theme is light , then there is a dark mode option. The text in the button was wrong earlier.

Fixes #164 

![gitcommit](https://github.com/user-attachments/assets/0cc1f18d-c2f0-4228-97af-abdcaa740e54)
