### PR TITLE
Feature/177 add metatags

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,14 @@
+---
+const { title = "Dev Encyclopedia", ...props } = Astro.props
+---
+
+<!-- Open Graph tags -->
+<meta property="og:title" content="Dev Encyclopedia" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://devpedia.dev/" />
+<meta
+  property="og:description"
+  content="Discover concise explanations and samples for tech terms and concepts in the Dev Encyclopedia. Find everything you need for development, all in one place."
+/>
+<meta property="og:image" content="" />
+<meta property="og:image:alt" content="" />

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -2,6 +2,21 @@
 const { title = "Dev Encyclopedia", ...props } = Astro.props
 ---
 
+<!-- Common meta tags -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="title" content={title} />
+<meta
+  name="description"
+  content="Discover concise explanations and samples for tech terms and concepts in the Dev Encyclopedia. Find everything you need for development, all in one place."
+/>
+<meta
+  name="keywords"
+  content="dev encyclopedia,developer encyclopedia,developer dictionary,developer resources,developer tools,software resources,programming resources,programming terms,tech terms"
+/>
+<meta name="robots" content="index,follow" />
+<meta name="language" content="en" />
+<meta name="author" content="Chenuli Jayasinghe" />
+
 <!-- Open Graph tags -->
 <meta property="og:title" content="Dev Encyclopedia" />
 <meta property="og:type" content="website" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,19 +7,7 @@ import Head from "../components/Head.astro"
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="title" content="Dev Encyclopedia" />
-    <meta
-      name="description"
-      content="Discover concise explanations and samples for tech terms and concepts in the Dev Encyclopedia. Find everything you need for development, all in one place."
-    />
-    <meta
-      name="keywords"
-      content="dev encyclopedia,developer encyclopedia,developer dictionary,developer resources,devpedia,developer tools,software resources,programming resources,programming terms,tech terms,developer wiki"
-    />
-    <meta name="robots" content="index,follow" />
-    <meta name="language" content="en" />
-    <meta name="author" content="Chenuli Jayasinghe" />
+    <Head />
 
     <title>Dev Encyclopedia | Encyclopedia for Developers</title>
     <link
@@ -31,7 +19,6 @@ import Head from "../components/Head.astro"
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
     />
-    <Head />
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-VEBVEDQRH5"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "bootstrap/dist/css/bootstrap.min.css"
 import "../styles/global.css"
+import Head from "../components/Head.astro"
 ---
 
 <html lang="en">
@@ -19,6 +20,7 @@ import "../styles/global.css"
     <meta name="robots" content="index,follow" />
     <meta name="language" content="en" />
     <meta name="author" content="Chenuli Jayasinghe" />
+
     <title>Dev Encyclopedia | Encyclopedia for Developers</title>
     <link
       rel="icon"
@@ -29,6 +31,8 @@ import "../styles/global.css"
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
     />
+    <Head />
+
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-VEBVEDQRH5"
     ></script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,23 +11,10 @@ const terms = await getCollection("terms")
 ---
 
 <head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta
     name="google-site-verification"
     content="-QKN9sbp37vkvEPbvMv7pz_OtmphW72Qoz_KhnNC3MI"
   />
-  <meta name="title" content="Dev Encyclopedia" />
-  <meta
-    name="description"
-    content="Discover concise explanations and samples for tech terms and concepts in the Dev Encyclopedia. Find everything you need for development, all in one place."
-  />
-  <meta
-    name="keywords"
-    content="dev encyclopedia,developer encyclopedia,developer dictionary,developer resources,developer tools,software resources,programming resources,programming terms,tech terms"
-  />
-  <meta name="robots" content="index,follow" />
-  <meta name="language" content="en" />
-  <meta name="author" content="Chenuli Jayasinghe" />
   <Head />
 
   <!-- Google tag (gtag.js) -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from "../layouts/BaseLayout.astro"
 import Hero from "../components/Hero.astro"
 import CardList from "../components/CardList.astro"
 import Modal from "../components/Modal.astro"
+import Head from "../components/Head.astro"
 
 import { getCollection } from "astro:content"
 
@@ -10,26 +11,43 @@ const terms = await getCollection("terms")
 ---
 
 <head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="google-site-verification" content="-QKN9sbp37vkvEPbvMv7pz_OtmphW72Qoz_KhnNC3MI" />
-  <meta name="title" content="Dev Encyclopedia">
-  <meta name="description" content="Discover concise explanations and samples for tech terms and concepts in the Dev Encyclopedia. Find everything you need for development, all in one place.">
-  <meta name="keywords" content="dev encyclopedia,developer encyclopedia,developer dictionary,developer resources,developer tools,software resources,programming resources,programming terms,tech terms">
-  <meta name="robots" content="index,follow">
-  <meta name="language" content="en">
-  <meta name="author" content="Chenuli Jayasinghe">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="google-site-verification"
+    content="-QKN9sbp37vkvEPbvMv7pz_OtmphW72Qoz_KhnNC3MI"
+  />
+  <meta name="title" content="Dev Encyclopedia" />
+  <meta
+    name="description"
+    content="Discover concise explanations and samples for tech terms and concepts in the Dev Encyclopedia. Find everything you need for development, all in one place."
+  />
+  <meta
+    name="keywords"
+    content="dev encyclopedia,developer encyclopedia,developer dictionary,developer resources,developer tools,software resources,programming resources,programming terms,tech terms"
+  />
+  <meta name="robots" content="index,follow" />
+  <meta name="language" content="en" />
+  <meta name="author" content="Chenuli Jayasinghe" />
+  <Head />
 
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-E51GWY7QV4"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-E51GWY7QV4"
+  ></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-E51GWY7QV4');
+    window.dataLayer = window.dataLayer || []
+    function gtag() {
+      dataLayer.push(arguments)
+    }
+    gtag("js", new Date())
+    gtag("config", "G-E51GWY7QV4")
   </script>
 
   <title>Dev Encyclopedia | Encyclopedia for Developers</title>
-  <link rel="icon" type="image/x-icon" href="https://ph-files.imgix.net/9669f231-c78f-4d66-889b-e4e3073c7f36.png?auto=compress&codec=mozjpeg&cs=strip&auto=format&w=72&h=72&fit=crop&dpr=2">
+  <link
+    rel="icon"
+    type="image/x-icon"
+    href="https://ph-files.imgix.net/9669f231-c78f-4d66-889b-e4e3073c7f36.png?auto=compress&codec=mozjpeg&cs=strip&auto=format&w=72&h=72&fit=crop&dpr=2"
+  />
 </head>
 
 <BaseLayout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
     "src/**/*",
     "public/card-actions.js"
   ],
+  "exclude": [
+    "coverage/",
+  ],
   "extends": [
     "astro/tsconfigs/strictest"
   ]


### PR DESCRIPTION
Improvements completed:

- (Fix) Exclude `coverage/` folder from tsconfig
- Added [OpenGraph](https://docs.astro.build/en/guides/configuring-astro/#add-site-metadata) meta tags
- Refactored common tags into new component (Head.astro)

Screenshot:
![image](https://github.com/user-attachments/assets/07ef3c8f-7ebf-4a6a-a271-52fa5391dbb8)

