### PR TITLE
Feature/205 add pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@commitlint/config-conventional": "^19.5.0",
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.11.1",
+        "@types/jsdom": "^21.1.7",
         "@typescript-eslint/parser": "^8.8.0",
         "@vitest/coverage-v8": "^2.1.9",
         "eslint": "^9.11.1",
@@ -2309,6 +2310,18 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2344,6 +2357,13 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -6539,6 +6559,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/check": "^0.9.2",
         "astro": "^4.16.18",
         "bootstrap": "^5.3.3",
+        "bootstrap-icons": "^1.13.1",
         "typescript": "^5.5.4"
       },
       "devDependencies": {
@@ -3202,6 +3203,22 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@commitlint/config-conventional": "^19.5.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.11.1",
+    "@types/jsdom": "^21.1.7",
     "@typescript-eslint/parser": "^8.8.0",
     "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,14 @@
     "preview": "astro preview",
     "prepare": "husky",
     "test": "vitest --run",
-
     "test:coverage": "vitest run --coverage",
-
     "lint": "prettier --write  \"**/*.{js,jsx,ts,tsx,astro}\" && eslint --fix \"src/**/*.{js,ts,jsx,tsx,astro}\""
   },
   "dependencies": {
     "@astrojs/check": "^0.9.2",
     "astro": "^4.16.18",
     "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.13.1",
     "typescript": "^5.5.4"
   },
   "devDependencies": {

--- a/src/components/CardList.astro
+++ b/src/components/CardList.astro
@@ -4,6 +4,24 @@ import type { CardProps } from "../types"
 const { terms: cards } = Astro.props
 ---
 
+<div class="pagination-bar">
+  <div class="pagination-filter">
+    <select class="select" id="pagination-select">
+      <option value={6}>6</option>
+      <option value={12}>12</option>
+      <option value={24}>24</option>
+    </select>
+  </div>
+
+  <button class="button navigation-button" id="prev-button">
+    <i class="bi bi-arrow-left-circle"></i>
+  </button>
+
+  <button class="button navigation-button" id="next-button">
+    <i class="bi bi-arrow-right-circle"></i>
+  </button>
+</div>
+
 <div class="card-container" id="cardContainer">
   {
     cards.map((card: CardProps) => (
@@ -22,3 +40,16 @@ const { terms: cards } = Astro.props
     ))
   }
 </div>
+
+<script>
+  const prevButton = document.getElementById("prev-button")
+  const nextButton = document.getElementById("next-button")
+
+  prevButton?.addEventListener("click", () => {
+    alert("Button was clicked")
+  })
+
+  nextButton?.addEventListener("click", () => {
+    alert("Click next button")
+  })
+</script>

--- a/src/components/CardList.astro
+++ b/src/components/CardList.astro
@@ -2,14 +2,25 @@
 import type { CardProps } from "../types"
 
 const { terms: cards } = Astro.props
+
+const paginateOptions = [
+  { label: "6", value: 6 },
+  { label: "12", value: 12 },
+  { label: "24", value: 24 },
+  { label: "48", value: 48 }
+]
 ---
 
 <div class="pagination-bar">
   <div class="pagination-filter">
     <select class="select" id="pagination-select">
-      <option value={6}>6</option>
-      <option value={12}>12</option>
-      <option value={24}>24</option>
+      {
+        paginateOptions.map((option) => (
+          <option value={option.value} id={`paginate-${option.label}`}>
+            {option.label}
+          </option>
+        ))
+      }
     </select>
   </div>
 
@@ -41,15 +52,11 @@ const { terms: cards } = Astro.props
   }
 </div>
 
-<script>
-  const prevButton = document.getElementById("prev-button")
-  const nextButton = document.getElementById("next-button")
+<!-- To-do -->
+<!--
+  [x] Implement pagination feature with buttons and dropdowns (6, 12, 24)
+  [ ] Implement unit test for pagination feature
+  [x] Migrate pagination feature to a new script (./scripts/pagination.ts)
+ -->
 
-  prevButton?.addEventListener("click", () => {
-    alert("Button was clicked")
-  })
-
-  nextButton?.addEventListener("click", () => {
-    alert("Click next button")
-  })
-</script>
+<script src="../scripts/paginate.ts"></script>

--- a/src/components/CardList.astro
+++ b/src/components/CardList.astro
@@ -51,12 +51,3 @@ const paginateOptions = [
     ))
   }
 </div>
-
-<!-- To-do -->
-<!--
-  [x] Implement pagination feature with buttons and dropdowns (6, 12, 24)
-  [x] Implement unit test for pagination feature
-  [x] Migrate pagination feature to a new script (./scripts/pagination.ts)
- -->
-
-<script src="../scripts/paginate.ts"></script>

--- a/src/components/CardList.astro
+++ b/src/components/CardList.astro
@@ -55,7 +55,7 @@ const paginateOptions = [
 <!-- To-do -->
 <!--
   [x] Implement pagination feature with buttons and dropdowns (6, 12, 24)
-  [ ] Implement unit test for pagination feature
+  [x] Implement unit test for pagination feature
   [x] Migrate pagination feature to a new script (./scripts/pagination.ts)
  -->
 

--- a/src/components/CardList.test.ts
+++ b/src/components/CardList.test.ts
@@ -1,5 +1,5 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container"
-import { expect, test } from "vitest"
+import { expect, test, describe, beforeEach, vi } from "vitest"
 import CardList from "./CardList.astro"
 
 describe("component UI display", () => {
@@ -75,6 +75,125 @@ describe("component UI display", () => {
     // Insert test assertion
     // component with class name = "card" should not be rendered
     expect(result).not.toContain("data-title")
+  })
+})
+
+describe("pagination functionality", () => {
+  let container: AstroContainer
+
+  beforeEach(async () => {
+    container = await AstroContainer.create()
+  })
+
+  test("renders pagination controls", async () => {
+    const mockCards = Array.from({ length: 10 }, (_, i) => ({
+      data: {
+        title: `Term ${i + 1}`,
+        subtext: `Subtext ${i + 1}`,
+        categories: ["Test"],
+        author: "Test Author",
+        description: {
+          title: `Term ${i + 1}`,
+          texts: [`Description for term ${i + 1}`],
+          image: "",
+          references: ["https://example.com"]
+        }
+      }
+    }))
+
+    const result = await container.renderToString(CardList, {
+      props: { terms: mockCards }
+    })
+
+    // Check pagination controls are rendered
+    expect(result).toContain('id="pagination-select"')
+    expect(result).toContain('id="prev-button"')
+    expect(result).toContain('id="next-button"')
+    expect(result).toContain('class="pagination-bar"')
+  })
+
+  test("renders pagination dropdown options", async () => {
+    const mockCards = [{
+      data: {
+        title: "Test Term",
+        subtext: "Test Subtext",
+        categories: ["Test"],
+        author: "Test Author",
+        description: {
+          title: "Test Term",
+          texts: ["Test description"],
+          image: "",
+          references: ["https://example.com"]
+        }
+      }
+    }]
+
+    const result = await container.renderToString(CardList, {
+      props: { terms: mockCards }
+    })
+
+    // Check all pagination options are present
+    expect(result).toContain('value="6"')
+    expect(result).toContain('value="12"')
+    expect(result).toContain('value="24"')
+    expect(result).toContain('value="48"')
+    expect(result).toContain('id="paginate-6"')
+    expect(result).toContain('id="paginate-12"')
+    expect(result).toContain('id="paginate-24"')
+    expect(result).toContain('id="paginate-48"')
+  })
+
+  test("renders all cards in container", async () => {
+    const mockCards = Array.from({ length: 8 }, (_, i) => ({
+      data: {
+        title: `Card ${i + 1}`,
+        subtext: `Subtext ${i + 1}`,
+        categories: ["Test"],
+        author: "Test Author",
+        description: {
+          title: `Card ${i + 1}`,
+          texts: [`Description ${i + 1}`],
+          image: "",
+          references: ["https://example.com"]
+        }
+      }
+    }))
+
+    const result = await container.renderToString(CardList, {
+      props: { terms: mockCards }
+    })
+
+    // Check that all cards are rendered (pagination logic happens in browser)
+    for (let i = 1; i <= 8; i++) {
+      expect(result).toContain(`Card ${i}`)
+    }
+    expect(result).toContain('id="cardContainer"')
+  })
+
+  test("renders navigation buttons with correct icons", async () => {
+    const mockCards = [{
+      data: {
+        title: "Test Term",
+        subtext: "Test Subtext",
+        categories: ["Test"],
+        author: "Test Author",
+        description: {
+          title: "Test Term",
+          texts: ["Test description"],
+          image: "",
+          references: ["https://example.com"]
+        }
+      }
+    }]
+
+    const result = await container.renderToString(CardList, {
+      props: { terms: mockCards }
+    })
+
+    // Check navigation buttons have correct Bootstrap icons
+    expect(result).toContain('class="bi bi-arrow-left-circle"')
+    expect(result).toContain('class="bi bi-arrow-right-circle"')
+    expect(result).toContain('class="button navigation-button"')
   })
 })
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+import "bootstrap-icons/font/bootstrap-icons.css"
+
 import BaseLayout from "../layouts/BaseLayout.astro"
 import Hero from "../components/Hero.astro"
 import CardList from "../components/CardList.astro"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,3 +48,4 @@ const terms = await getCollection("terms")
 <script src="../scripts/cards.ts"></script>
 <script src="../scripts/modal.ts"></script>
 <script src="../scripts/hero-action.ts"></script>
+<script src="../scripts/paginate.ts"></script>

--- a/src/scripts/hero-action.ts
+++ b/src/scripts/hero-action.ts
@@ -1,5 +1,5 @@
 class Hero extends HTMLElement {
-  
+
   constructor() {
     super()
 
@@ -29,7 +29,12 @@ class Hero extends HTMLElement {
       searchInput.value = ""
 
       if (selectedCategory === "") {
-        cards.forEach((card: HTMLElement) => (card.style.display = ""))
+        cards.forEach((card: HTMLElement) => {
+          card.style.display = ""
+          card.removeAttribute('data-hidden-by-filter')
+        })
+        // Trigger pagination refresh
+        window.dispatchEvent(new CustomEvent('cardsFiltered'))
         return
       }
       for (let i = 0; i < cards.length; i++) {
@@ -37,10 +42,14 @@ class Hero extends HTMLElement {
           cards[i]!.getAttribute("data-categories")!.split(", ")
         if (cardCategories.includes(selectedCategory)) {
           ;(cards[i] as HTMLElement).style.display = ""
+          ;(cards[i] as HTMLElement).removeAttribute('data-hidden-by-filter')
         } else {
           ;(cards[i] as HTMLElement).style.display = "none"
+          ;(cards[i] as HTMLElement).setAttribute('data-hidden-by-filter', 'true')
         }
       }
+      // Trigger pagination refresh
+      window.dispatchEvent(new CustomEvent('cardsFiltered'))
     })
 
     let currentFocus = -1 // Track the currently focused item in the autocomplete list
@@ -168,10 +177,14 @@ class Hero extends HTMLElement {
           filterByCategory(selectedCategory, cardCategories)
         ) {
           ;(cards[i] as HTMLElement).style.display = ""
+          ;(cards[i] as HTMLElement).removeAttribute('data-hidden-by-filter')
         } else {
           ;(cards[i] as HTMLElement).style.display = "none"
+          ;(cards[i] as HTMLElement).setAttribute('data-hidden-by-filter', 'true')
         }
       }
+      // Trigger pagination refresh
+      window.dispatchEvent(new CustomEvent('cardsFiltered'))
     }
   }
 }

--- a/src/scripts/paginate.test.ts
+++ b/src/scripts/paginate.test.ts
@@ -1,0 +1,271 @@
+import { describe, test, expect, beforeEach, vi } from "vitest"
+import { JSDOM } from "jsdom"
+
+// Global DOM variable
+let dom: JSDOM
+
+// Mock DOM environment
+const setupDOM = (cardCount: number = 10) => {
+  dom = new JSDOM(`
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <div class="pagination-bar">
+          <select id="pagination-select">
+            <option value="6">6</option>
+            <option value="12">12</option>
+            <option value="24">24</option>
+            <option value="48">48</option>
+          </select>
+          <button id="prev-button">Previous</button>
+          <button id="next-button">Next</button>
+        </div>
+        <div id="cardContainer">
+          ${Array.from({ length: cardCount }, (_, i) =>
+            `<div class="card" data-title="Card ${i + 1}">Card ${i + 1}</div>`
+          ).join('')}
+        </div>
+      </body>
+    </html>
+  `)
+
+  global.document = dom.window.document
+  global.window = dom.window as any
+  global.Event = dom.window.Event
+}
+
+// Simple PaginationManager class for testing (extracted from paginate.ts)
+class PaginationManager {
+  private cards: HTMLElement[]
+  private currentPage: number = 1
+  private itemsPerPage: number = 6
+  private totalPages: number = 1
+
+  constructor() {
+    this.cards = Array.from(document.querySelectorAll(".card"))
+    this.init()
+  }
+
+  private init() {
+    this.calculateTotalPages()
+    this.setupEventListeners()
+    this.showCurrentPage()
+    this.updateButtonStates()
+  }
+
+  private setupEventListeners() {
+    const paginateSelect = document.getElementById("pagination-select") as HTMLSelectElement
+    const prevButton = document.getElementById("prev-button")
+    const nextButton = document.getElementById("next-button")
+
+    paginateSelect?.addEventListener("change", (e) => {
+      const target = e.target as HTMLSelectElement
+      this.itemsPerPage = parseInt(target.value)
+      this.currentPage = 1
+      this.calculateTotalPages()
+      this.showCurrentPage()
+      this.updateButtonStates()
+    })
+
+    prevButton?.addEventListener("click", () => {
+      if (this.currentPage > 1) {
+        this.currentPage--
+        this.showCurrentPage()
+        this.updateButtonStates()
+      }
+    })
+
+    nextButton?.addEventListener("click", () => {
+      if (this.currentPage < this.totalPages) {
+        this.currentPage++
+        this.showCurrentPage()
+        this.updateButtonStates()
+      }
+    })
+  }
+
+  private calculateTotalPages() {
+    this.totalPages = Math.ceil(this.cards.length / this.itemsPerPage)
+  }
+
+  private showCurrentPage() {
+    const startIndex = (this.currentPage - 1) * this.itemsPerPage
+    const endIndex = startIndex + this.itemsPerPage
+
+    this.cards.forEach((card) => {
+      card.style.display = "none"
+    })
+
+    this.cards.slice(startIndex, endIndex).forEach((card) => {
+      card.style.display = "block"
+    })
+  }
+
+  private updateButtonStates() {
+    const prevButton = document.getElementById("prev-button") as HTMLButtonElement
+    const nextButton = document.getElementById("next-button") as HTMLButtonElement
+
+    if (prevButton) {
+      prevButton.disabled = this.currentPage === 1
+      prevButton.style.opacity = this.currentPage === 1 ? "0.5" : "1"
+    }
+
+    if (nextButton) {
+      nextButton.disabled = this.currentPage === this.totalPages
+      nextButton.style.opacity = this.currentPage === this.totalPages ? "0.5" : "1"
+    }
+  }
+
+  // Public methods for testing
+  public getCurrentPage(): number {
+    return this.currentPage
+  }
+
+  public getTotalPages(): number {
+    return this.totalPages
+  }
+
+  public getItemsPerPage(): number {
+    return this.itemsPerPage
+  }
+
+  public getVisibleCards(): HTMLElement[] {
+    return this.cards.filter(card => card.style.display !== "none")
+  }
+}
+
+describe("PaginationManager", () => {
+  let paginationManager: PaginationManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("initializes with correct default values", () => {
+    setupDOM(10)
+    paginationManager = new PaginationManager()
+
+    expect(paginationManager.getCurrentPage()).toBe(1)
+    expect(paginationManager.getItemsPerPage()).toBe(6)
+    expect(paginationManager.getTotalPages()).toBe(2) // 10 cards / 6 per page = 2 pages
+  })
+
+  test("shows correct number of cards on first page", () => {
+    setupDOM(10)
+    paginationManager = new PaginationManager()
+
+    const visibleCards = paginationManager.getVisibleCards()
+    expect(visibleCards).toHaveLength(6)
+  })
+
+  test("navigates to next page correctly", () => {
+    setupDOM(10)
+    paginationManager = new PaginationManager()
+
+    const nextButton = document.getElementById("next-button") as HTMLButtonElement
+    nextButton.click()
+
+    expect(paginationManager.getCurrentPage()).toBe(2)
+    const visibleCards = paginationManager.getVisibleCards()
+    expect(visibleCards).toHaveLength(4) // Remaining 4 cards on page 2
+  })
+
+  test("navigates to previous page correctly", () => {
+    setupDOM(10)
+    paginationManager = new PaginationManager()
+
+    // Go to page 2 first
+    const nextButton = document.getElementById("next-button") as HTMLButtonElement
+    nextButton.click()
+
+    // Then go back to page 1
+    const prevButton = document.getElementById("prev-button") as HTMLButtonElement
+    prevButton.click()
+
+    expect(paginationManager.getCurrentPage()).toBe(1)
+    const visibleCards = paginationManager.getVisibleCards()
+    expect(visibleCards).toHaveLength(6)
+  })
+
+  test("changes items per page when dropdown changes", () => {
+    setupDOM(15)
+    paginationManager = new PaginationManager()
+
+    const select = document.getElementById("pagination-select") as HTMLSelectElement
+    select.value = "12"
+    select.dispatchEvent(new Event("change"))
+
+    expect(paginationManager.getItemsPerPage()).toBe(12)
+    expect(paginationManager.getTotalPages()).toBe(2) // 15 cards / 12 per page = 2 pages
+    expect(paginationManager.getCurrentPage()).toBe(1) // Should reset to page 1
+  })
+
+  test("disables previous button on first page", () => {
+    setupDOM(10)
+    paginationManager = new PaginationManager()
+
+    const prevButton = document.getElementById("prev-button") as HTMLButtonElement
+    expect(prevButton.disabled).toBe(true)
+    expect(prevButton.style.opacity).toBe("0.5")
+  })
+
+  test("disables next button on last page", () => {
+    setupDOM(10)
+    paginationManager = new PaginationManager()
+
+    // Navigate to last page
+    const nextButton = document.getElementById("next-button") as HTMLButtonElement
+    nextButton.click()
+
+    expect(nextButton.disabled).toBe(true)
+    expect(nextButton.style.opacity).toBe("0.5")
+  })
+
+  test("handles single page correctly", () => {
+    setupDOM(3) // Only 3 cards, so 1 page with 6 items per page
+    paginationManager = new PaginationManager()
+
+    expect(paginationManager.getTotalPages()).toBe(1)
+
+    const prevButton = document.getElementById("prev-button") as HTMLButtonElement
+    const nextButton = document.getElementById("next-button") as HTMLButtonElement
+
+    expect(prevButton.disabled).toBe(true)
+    expect(nextButton.disabled).toBe(true)
+  })
+
+  test("calculates total pages correctly with different page sizes", () => {
+    setupDOM(25)
+    paginationManager = new PaginationManager()
+
+    // Test with 6 items per page
+    expect(paginationManager.getTotalPages()).toBe(5) // 25 / 6 = 4.17 -> 5 pages
+
+    // Change to 12 items per page
+    const select = document.getElementById("pagination-select") as HTMLSelectElement
+    select.value = "12"
+    select.dispatchEvent(new Event("change"))
+    expect(paginationManager.getTotalPages()).toBe(3) // 25 / 12 = 2.08 -> 3 pages
+
+    // Change to 48 items per page
+    select.value = "48"
+    select.dispatchEvent(new Event("change"))
+    expect(paginationManager.getTotalPages()).toBe(1) // 25 / 48 = 0.52 -> 1 page
+  })
+
+  test("prevents navigation beyond boundaries", () => {
+    setupDOM(6) // Exactly 1 page
+    paginationManager = new PaginationManager()
+
+    const prevButton = document.getElementById("prev-button") as HTMLButtonElement
+    const nextButton = document.getElementById("next-button") as HTMLButtonElement
+
+    // Try to go to previous page (should stay at 1)
+    prevButton.click()
+    expect(paginationManager.getCurrentPage()).toBe(1)
+
+    // Try to go to next page (should stay at 1)
+    nextButton.click()
+    expect(paginationManager.getCurrentPage()).toBe(1)
+  })
+})

--- a/src/scripts/paginate.ts
+++ b/src/scripts/paginate.ts
@@ -1,0 +1,109 @@
+  class PaginationManager {
+    private cards: HTMLElement[]
+    private currentPage: number = 1
+    private itemsPerPage: number = 6
+    private totalPages: number = 1
+
+    constructor() {
+      this.cards = Array.from(document.querySelectorAll(".card"))
+      this.init()
+    }
+
+    private init() {
+      this.calculateTotalPages()
+      this.setupEventListeners()
+      this.showCurrentPage()
+      this.updateButtonStates()
+    }
+
+    private setupEventListeners() {
+      const paginateSelect = document.getElementById(
+        "pagination-select"
+      ) as HTMLSelectElement
+      const prevButton = document.getElementById("prev-button")
+      const nextButton = document.getElementById("next-button")
+
+      // Handle dropdown change
+      paginateSelect?.addEventListener("change", (e) => {
+        const target = e.target as HTMLSelectElement
+        this.itemsPerPage = parseInt(target.value)
+        this.currentPage = 1 // Reset to first page
+        this.calculateTotalPages()
+        this.showCurrentPage()
+        this.updateButtonStates()
+      })
+
+      // Handle previous button click
+      prevButton?.addEventListener("click", () => {
+        if (this.currentPage > 1) {
+          this.currentPage--
+          this.showCurrentPage()
+          this.updateButtonStates()
+        }
+      })
+
+      // Handle next button click
+      nextButton?.addEventListener("click", () => {
+        if (this.currentPage < this.totalPages) {
+          this.currentPage++
+          this.showCurrentPage()
+          this.updateButtonStates()
+        }
+      })
+    }
+
+    private calculateTotalPages() {
+      this.totalPages = Math.ceil(this.cards.length / this.itemsPerPage)
+    }
+
+    private showCurrentPage() {
+      const startIndex = (this.currentPage - 1) * this.itemsPerPage
+      const endIndex = startIndex + this.itemsPerPage
+
+      // Hide all cards
+      this.cards.forEach((card) => {
+        card.style.display = "none"
+      })
+
+      // Show cards for current page
+      this.cards.slice(startIndex, endIndex).forEach((card) => {
+        card.style.display = "block"
+      })
+    }
+
+    private updateButtonStates() {
+      const prevButton = document.getElementById(
+        "prev-button"
+      ) as HTMLButtonElement
+      const nextButton = document.getElementById(
+        "next-button"
+      ) as HTMLButtonElement
+
+      // Disable/enable previous button
+      if (prevButton) {
+        prevButton.disabled = this.currentPage === 1
+        prevButton.style.opacity = this.currentPage === 1 ? "0.5" : "1"
+      }
+
+      // Disable/enable next button
+      if (nextButton) {
+        nextButton.disabled = this.currentPage === this.totalPages
+        nextButton.style.opacity =
+          this.currentPage === this.totalPages ? "0.5" : "1"
+      }
+    }
+  }
+
+  // Initialize pagination when DOM is loaded
+  document.addEventListener("DOMContentLoaded", () => {
+    new PaginationManager()
+  })
+
+  // Also initialize immediately if DOM is already loaded
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      new PaginationManager()
+    })
+  } else {
+    new PaginationManager()
+  }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,7 +15,7 @@
 select {
   /* A reset of styles, including removing the default dropdown arrow */
   appearance: none;
-   /* Additional resets for further consistency */
+  /* Additional resets for further consistency */
   background-color: transparent;
   border: none;
   padding: 0 1em 0 0;
@@ -54,10 +54,10 @@ select,
 
 @font-face {
   font-display: swap;
-  font-family: 'JetBrains Mono';
+  font-family: "JetBrains Mono";
   font-style: normal;
   font-weight: 400;
-  src: url('/fonts/jetbrains-mono-v18-latin-regular.woff2') format('woff2');
+  src: url("/fonts/jetbrains-mono-v18-latin-regular.woff2") format("woff2");
 }
 
 img {
@@ -68,7 +68,7 @@ img {
 body {
   background-color: #fcfcfc;
   color: #000000;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   margin: 0;
   padding: 0;
 }
@@ -157,7 +157,7 @@ body {
 
 #autocomplete-list {
   max-height: 200px; /* Ensure there's a maximum height */
-  overflow-y: auto;  /* Enable vertical scrolling */
+  overflow-y: auto; /* Enable vertical scrolling */
   scrollbar-width: thin; /* Firefox */
   position: absolute;
 }
@@ -231,7 +231,7 @@ body {
   border-color: black;
   color: #000000;
   padding: 15px 30px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   cursor: pointer;
   text-align: center;
   border-radius: 5px;
@@ -294,7 +294,9 @@ body.dark-mode .explain-button:hover {
   box-shadow: 5px 5px rgb(237, 237, 237);
 }
 
-body.dark-mode .search-bar input, body.dark-mode #category-select {
+body.dark-mode .search-bar input,
+body.dark-mode #category-select,
+body.dark-mode #pagination-select {
   background-color: #444444;
   color: #ffffff !important;
   border-color: #d2d2d2;
@@ -304,11 +306,21 @@ body.dark-mode .search-bar i {
   color: #cccccc;
 }
 
-body.dark-mode #category-select {
-  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>") no-repeat;
+body.dark-mode #pagination-select {
+  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>")
+    no-repeat;
   background-position: calc(100% - 1.2rem) center !important;
-  -moz-appearance:none !important;
-  -webkit-appearance: none !important; 
+  -moz-appearance: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+}
+
+body.dark-mode #category-select {
+  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>")
+    no-repeat;
+  background-position: calc(100% - 1.2rem) center !important;
+  -moz-appearance: none !important;
+  -webkit-appearance: none !important;
   appearance: none !important;
   padding-right: 2rem !important;
 }
@@ -340,17 +352,20 @@ body.dark-mode input[type="text"]::placeholder {
   gap: 20px;
 }
 
-.search-bar, .category-filter {
+.search-bar,
+.category-filter,
+.pagination-filter {
   position: relative;
   display: inline-block;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
 }
 
-.search-bar input, #category-select {
+.search-bar input,
+#category-select {
   font-size: 1em;
   border: 1px solid #000000;
   border-radius: 35px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
 }
 
 .search-bar input {
@@ -372,10 +387,11 @@ body.dark-mode input[type="text"]::placeholder {
   text-align: center;
   color: #555;
 
-  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>") no-repeat;
+  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>")
+    no-repeat;
   background-position: calc(100% - 1.2rem) center !important;
-  -moz-appearance:none !important;
-  -webkit-appearance: none !important; 
+  -moz-appearance: none !important;
+  -webkit-appearance: none !important;
   appearance: none !important;
   padding-right: 2rem !important;
 }
@@ -422,12 +438,63 @@ body.dark-mode select option {
   margin-bottom: 20px;
 }
 
+.pagination-bar {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 20px;
+}
+
+#pagination-select {
+  font-size: 1em;
+  border: 1px solid #000000;
+  font-family: "JetBrains Mono", monospace;
+  padding: 10px;
+  width: 75px;
+  border-radius: 35px;
+  text-align: left;
+  color: #555;
+  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>")
+    no-repeat;
+  background-position: calc(100% - 1.2rem) center !important;
+  -moz-appearance: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+}
+
+.navigation-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.navigation-button i {
+  font-size: 2rem;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.navigation-button:hover i {
+  transform: scale(1.1);
+  transition: transform 0.2s ease;
+}
+
 .explain-button {
   background-color: #000;
   color: #fff;
   padding: 18px;
   border-radius: 5px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   cursor: pointer;
   width: 85%;
   transition: all 0.3s linear;
@@ -462,7 +529,7 @@ body.dark-mode select option {
   border-radius: 10px;
   width: 80%;
   max-width: 600px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   overflow-y: auto;
   max-height: 70vh;
 }
@@ -499,7 +566,7 @@ body.modal-open {
   border-radius: 5px;
   font-size: 15px;
   text-align: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   cursor: pointer;
 }
 


### PR DESCRIPTION
# Include paginatio logic to home page

Improvements completed:
- Add in pagination logic with options of 6, 12, 24, 48 cards to display (`6` is default)
- Include previous and next button to allow user navigating through results
- Include test scripts for pagination logic

## Screenshot:
### Before
<img width="1906" height="986" alt="image" src="https://github.com/user-attachments/assets/09977026-8e3d-4b89-a290-19b6f2e6e0b1" />

### After
<img width="1917" height="967" alt="image" src="https://github.com/user-attachments/assets/2cb8d1de-b1b7-4eb1-8ba3-b7896be9247a" />

